### PR TITLE
Fix unicode error in context show, #6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - pip install -e .
 
 before_script:
-    - git config --global user.name 'Travis CI'
+    - git config --global user.name 'Travis CI and ön'
     - git config --global user.email 'test@exmaple.com'
 
 script:

--- a/choosealicense/cli.py
+++ b/choosealicense/cli.py
@@ -91,5 +91,5 @@ def context(license):
         default_context = get_default_context()
         echo('The template has following defaults:')
         for item in context:
-            echo('\t{0}: {1}'.format(item, default_context[item]))
+            echo(u'\t{0}: {1}'.format(item, default_context[item]))
         echo('You can overwrite them at your ease.')

--- a/choosealicense/test/test_context.py
+++ b/choosealicense/test/test_context.py
@@ -11,6 +11,21 @@ from choosealicense.cli import context, LICENSE_WITH_CONTEXT
 from choosealicense.utils import get_default_context
 
 
+context_template = u'''\
+The template has following defaults:
+\tyear: {0}
+\tfullname: {1}
+You can overwrite them at your ease.
+'''
+context_with_email_template = u'''\
+The template has following defaults:
+\tyear: {0}
+\tfullname: {1}
+\temail: {2}
+You can overwrite them at your ease.
+'''
+
+
 @pytest.mark.usefixtures('mock_api')
 class TestContext():
     def test_show_license_context(self, runner):
@@ -28,28 +43,11 @@ class TestContext():
             else:
                 defaults = get_default_context()
 
-                if license in ['mit', 'artistic-2.0', 'bsd-2-clause']:
-                    assert output == (
-                        "The template has following defaults:\n"
-                        "\tyear: {0}\n"
-                        "\tfullname: {1}\n"
-                        "You can overwrite them at your ease.\n").format(
-                            defaults['year'], defaults['fullname'])
+                if license in ['mit', 'artistic-2.0', 'bsd-2-clause', 'bsd-3-clause']:
+                    assert output == context_template.format(
+                        defaults['year'], defaults['fullname'])
 
                 if license == 'isc':
-                    assert output == (
-                        "The template has following defaults:\n"
-                        "\tyear: {0}\n"
-                        "\tfullname: {1}\n"
-                        "\temail: {2}\n"
-                        "You can overwrite them at your ease.\n").format(
+                    assert output == context_with_email_template.format(
                             defaults['year'], defaults['fullname'],
                             defaults['email'])
-
-                if license == 'bsd-3-clause':
-                    assert output == (
-                        "The template has following defaults:\n"
-                        "\tyear: {0}\n"
-                        "\tfullname: {1}\n"
-                        "You can overwrite them at your ease.\n").format(
-                            defaults['year'], defaults['fullname'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [bdist_wheel]
 universal = 1
+[flake8]
+max-line-length = 108


### PR DESCRIPTION
### about this pr

* fix `license context` when user.name has non ascii char.