### PR TITLE
✨ Make license names case insensitive

### DIFF
--- a/choosealicense/cli.py
+++ b/choosealicense/cli.py
@@ -17,6 +17,11 @@ LICENSE_WITH_CONTEXT = ['mit', 'artistic-2.0', 'bsd-2-clause',
                         'bsd-3-clause', 'isc']
 
 
+def to_lower(ctx, param, value):
+    """Callback to lower case the value of a click argument"""
+    return value.lower()
+
+
 @click.group(context_settings={'help_option_names': ('-h', '--help')})
 @click.version_option(__version__, '-V', '--version', message='%(version)s')
 def cli():
@@ -33,7 +38,7 @@ def show():
 
 
 @cli.command()
-@click.argument('license')
+@click.argument('license', callback=to_lower)
 def info(license):
     """Show the info of the specified license."""
     response = get_api_response(
@@ -50,7 +55,7 @@ def info(license):
 @click.option('--year', '-y', help="Copyright year")
 @click.option('--email', '-e', help="Copyright holder's email")
 @click.option('--project', '-p', help="The project organization")
-@click.argument('license')
+@click.argument('license', callback=to_lower)
 def generate(license, fullname, year, email, project):
     """Generate the specified license."""
     response = get_api_response(
@@ -79,7 +84,7 @@ def generate(license, fullname, year, email, project):
 
 
 @cli.command()
-@click.argument('license')
+@click.argument('license', callback=to_lower)
 def context(license):
     """Show the default context for the license."""
     if license not in LICENSE_WITH_CONTEXT:

--- a/choosealicense/test/test_generate.py
+++ b/choosealicense/test/test_generate.py
@@ -14,11 +14,15 @@ from choosealicense.utils import get_default_context
 @pytest.mark.usefixtures('mock_api')
 class TestGenerate():
     def test_generate_license(self, runner):
-        all_the_licenses = (
-            'agpl-3.0, apache-2.0, artistic-2.0, bsd-2-clause, '
-            'bsd-3-clause, cc0-1.0, epl-1.0, gpl-2.0, gpl-3.0, '
-            'isc, lgpl-2.1, lgpl-3.0, mit, mpl-2.0, unlicense')
-        for license in all_the_licenses.split(', '):
+        all_the_licenses = [
+            'agpl-3.0', 'apache-2.0', 'artistic-2.0', 'bsd-2-clause',
+            'bsd-3-clause', 'cc0-1.0', 'epl-1.0', 'gpl-2.0', 'gpl-3.0',
+            'isc', 'lgpl-2.1', 'lgpl-3.0', 'mit', 'mpl-2.0', 'unlicense'
+        ]
+
+        all_the_licences_upper_cased = [licence.upper() for licence in all_the_licenses]
+
+        for license in all_the_licenses + all_the_licences_upper_cased:
             result = runner.invoke(generate, [license])
             output, exit_code = result.output, result.exit_code
             assert exit_code == 0
@@ -29,16 +33,16 @@ class TestGenerate():
             else:
                 defaults = get_default_context()
 
-                if license in ['mit', 'artistic-2.0', 'bsd-2-clause']:
+                if license.lower() in ['mit', 'artistic-2.0', 'bsd-2-clause']:
                     assert defaults['fullname'] in output
                     assert defaults['year'] in output
 
-                if license == 'isc':
+                if license.lower() == 'isc':
                     assert defaults['fullname'] in output
                     assert defaults['year'] in output
                     assert defaults['email'] in output
 
-                if license == 'bsd-3-clause':
+                if license.lower() == 'bsd-3-clause':
                     assert defaults['fullname'] in output
                     assert defaults['year'] in output
                     assert defaults['project'] in output


### PR DESCRIPTION
For example, allows running `license generate MIT` with equivalent results as `license generate mit`.

Fixes #12 